### PR TITLE
Inject server ip

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -10,6 +10,24 @@
     </parent>
 
     <artifactId>client</artifactId>
-    <version>0.9</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>io.github.expansionteam.battleships.MainLauncher</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>
 

--- a/client/src/main/java/io/github/expansionteam/battleships/BattleshipsModule.java
+++ b/client/src/main/java/io/github/expansionteam/battleships/BattleshipsModule.java
@@ -6,11 +6,13 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import io.github.expansionteam.battleships.gui.GameState;
 import io.github.expansionteam.battleships.logic.AsyncTask;
+import io.github.expansionteam.battleships.logic.ConnectionConfig;
 import io.github.expansionteam.battleships.logic.message.MessageProcessor;
 import io.github.expansionteam.battleships.logic.message.MessageProcessorProvider;
 import io.github.expansionteam.battleships.logic.message.MessageSender;
 import io.github.expansionteam.battleships.logic.message.MessageSenderProvider;
 
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class BattleshipsModule extends AbstractModule {
@@ -38,4 +40,8 @@ public class BattleshipsModule extends AbstractModule {
         return new GameState();
     }
 
+    @Provides
+    @Singleton
+    public ConnectionConfig provideConnectionConfig() {
+        return new ConnectionConfig();}
 }

--- a/client/src/main/java/io/github/expansionteam/battleships/MainLauncher.java
+++ b/client/src/main/java/io/github/expansionteam/battleships/MainLauncher.java
@@ -1,6 +1,7 @@
 package io.github.expansionteam.battleships;
 
 import com.google.common.eventbus.EventBus;
+import com.google.common.net.InetAddresses;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import io.github.expansionteam.battleships.logic.ConnectionConfig;
@@ -48,11 +49,19 @@ public class MainLauncher extends Application {
 
     private void configureServerIp(Injector injector) {
         if (Objects.nonNull(getParameters()) && !CollectionUtils.isEmpty(getParameters().getRaw())) {
-            List<String> parameters = getParameters().getRaw();
-            String serverIp = parameters.get(0);
-            log.debug("Server ip address is: " + serverIp);
-            connectionConfig = injector.getInstance(ConnectionConfig.class);
-            connectionConfig.setServerIp(serverIp);
+            List<String> parameters;
+            String serverIp = "";
+            try {
+                parameters = getParameters().getRaw();
+                serverIp = parameters.get(0);
+                InetAddresses.forString(serverIp);
+                log.debug("Server ip address is: " + serverIp);
+                connectionConfig = injector.getInstance(ConnectionConfig.class);
+                connectionConfig.setServerIp(serverIp);
+            } catch (IllegalArgumentException e) {
+                log.error(serverIp + " is invalid ip address.");
+                System.exit(1);
+            }
         }
     }
 

--- a/client/src/main/java/io/github/expansionteam/battleships/MainLauncher.java
+++ b/client/src/main/java/io/github/expansionteam/battleships/MainLauncher.java
@@ -21,7 +21,8 @@ import java.util.Objects;
 public class MainLauncher extends Application {
 
     private final static Logger log = Logger.getLogger(MainLauncher.class);
-    private ConnectionConfig connectionConfig;
+    private static final int WINDOW_WIDTH = 800;
+    private static final int WINDOW_HEIGHT = 600;
 
     @Override
     public void start(Stage primaryStage) throws Exception {
@@ -36,10 +37,10 @@ public class MainLauncher extends Application {
             eventBus.register(controller);
             return controller;
         });
-        primaryStage.setMinWidth(800);
-        primaryStage.setMinHeight(600);
+        primaryStage.setMinWidth(WINDOW_WIDTH);
+        primaryStage.setMinHeight(WINDOW_HEIGHT);
         primaryStage.setTitle("Battleships");
-        primaryStage.setScene(new Scene(root, 800, 600));
+        primaryStage.setScene(new Scene(root, WINDOW_WIDTH, WINDOW_HEIGHT));
         primaryStage.show();
     }
 
@@ -56,7 +57,7 @@ public class MainLauncher extends Application {
                 serverIp = parameters.get(0);
                 InetAddresses.forString(serverIp);
                 log.debug("Server ip address is: " + serverIp);
-                connectionConfig = injector.getInstance(ConnectionConfig.class);
+                ConnectionConfig connectionConfig = injector.getInstance(ConnectionConfig.class);
                 connectionConfig.setServerIp(serverIp);
             } catch (IllegalArgumentException e) {
                 log.error(serverIp + " is invalid ip address.");

--- a/client/src/main/java/io/github/expansionteam/battleships/MainLauncher.java
+++ b/client/src/main/java/io/github/expansionteam/battleships/MainLauncher.java
@@ -3,6 +3,7 @@ package io.github.expansionteam.battleships;
 import com.google.common.eventbus.EventBus;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import io.github.expansionteam.battleships.logic.ConnectionConfig;
 import io.github.expansionteam.battleships.logic.event.EventHandler;
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
@@ -10,15 +11,21 @@ import javafx.fxml.JavaFXBuilderFactory;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.log4j.Logger;
+
+import java.util.List;
+import java.util.Objects;
 
 public class MainLauncher extends Application {
 
     private final static Logger log = Logger.getLogger(MainLauncher.class);
+    private ConnectionConfig connectionConfig;
 
     @Override
     public void start(Stage primaryStage) throws Exception {
         Injector injector = Guice.createInjector(new BattleshipsModule());
+        configureServerIp(injector);
         EventBus eventBus = injector.getInstance(EventBus.class);
 
         eventBus.register(injector.getInstance(EventHandler.class));
@@ -37,6 +44,16 @@ public class MainLauncher extends Application {
 
     public static void main(String[] args) {
         launch(args);
+    }
+
+    private void configureServerIp(Injector injector) {
+        if (Objects.nonNull(getParameters()) && !CollectionUtils.isEmpty(getParameters().getRaw())) {
+            List<String> parameters = getParameters().getRaw();
+            String serverIp = parameters.get(0);
+            log.debug("Server ip address is: " + serverIp);
+            connectionConfig = injector.getInstance(ConnectionConfig.class);
+            connectionConfig.setServerIp(serverIp);
+        }
     }
 
 }

--- a/client/src/main/java/io/github/expansionteam/battleships/logic/ConnectionConfig.java
+++ b/client/src/main/java/io/github/expansionteam/battleships/logic/ConnectionConfig.java
@@ -1,0 +1,15 @@
+package io.github.expansionteam.battleships.logic;
+
+public class ConnectionConfig {
+
+    private static final String LOCAL_SERVER_IP = "127.0.0.1";
+    private String serverIp = LOCAL_SERVER_IP;
+
+    public String getServerIp() {
+        return serverIp;
+    }
+
+    public void setServerIp(String serverIp) {
+        this.serverIp = serverIp;
+    }
+}

--- a/client/src/main/java/io/github/expansionteam/battleships/logic/message/MessageSenderProvider.java
+++ b/client/src/main/java/io/github/expansionteam/battleships/logic/message/MessageSenderProvider.java
@@ -2,6 +2,7 @@ package io.github.expansionteam.battleships.logic.message;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import io.github.expansionteam.battleships.logic.ConnectionConfig;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
@@ -13,10 +14,12 @@ public class MessageSenderProvider implements Provider<MessageSender> {
 
     private final static Logger log = Logger.getLogger(MessageSenderProvider.class);
 
-    private static final String IP = "127.0.0.1";
     private static final int PORT = 1234;
 
     private final MessageFactory messageFactory;
+
+    @Inject
+    ConnectionConfig connectionConfig;
 
     @Inject
     public MessageSenderProvider(MessageFactory messageFactory) {
@@ -26,7 +29,7 @@ public class MessageSenderProvider implements Provider<MessageSender> {
     @Override
     public MessageSender get() {
         try {
-            SocketAddress socketAddress = new InetSocketAddress(IP, PORT);
+            SocketAddress socketAddress = new InetSocketAddress(connectionConfig.getServerIp(), PORT);
 
             SocketChannel socketChannel = SocketChannel.open(socketAddress);
             socketChannel.configureBlocking(true);

--- a/client/src/main/resources/log4j.properties
+++ b/client/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 # Root logger option
-log4j.rootLogger=DEBUG, stdout, file
+log4j.rootLogger=TRACE, stdout, file
 
 # Redirect log messages to console
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender

--- a/client/src/test/java/io/github/expansionteam/battleships/logic/ConnectionConfigTest.java
+++ b/client/src/test/java/io/github/expansionteam/battleships/logic/ConnectionConfigTest.java
@@ -1,18 +1,34 @@
 package io.github.expansionteam.battleships.logic;
 
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ConnectionConfigTest {
+
+    private ConnectionConfig connectionConfig;
+    private String LOCALHOST = "127.0.0.1";
+
+
+    @BeforeMethod
+    public void setUp() {
+        connectionConfig = new ConnectionConfig();
+    }
+
     @Test
     public void testGetServerIp() throws Exception {
-    //TODO
+        assertThat(connectionConfig.getServerIp(), is(LOCALHOST));
     }
 
     @Test
     public void testSetServerIp() throws Exception {
-    //TODO
+        String serverIp = "10.20.30.10";
+        connectionConfig.setServerIp(serverIp);
+        assertThat(connectionConfig.getServerIp(), is(serverIp));
+        assertThat(connectionConfig.getServerIp(), is(not(LOCALHOST)));
     }
 
 }

--- a/client/src/test/java/io/github/expansionteam/battleships/logic/ConnectionConfigTest.java
+++ b/client/src/test/java/io/github/expansionteam/battleships/logic/ConnectionConfigTest.java
@@ -1,0 +1,18 @@
+package io.github.expansionteam.battleships.logic;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class ConnectionConfigTest {
+    @Test
+    public void testGetServerIp() throws Exception {
+    //TODO
+    }
+
+    @Test
+    public void testSetServerIp() throws Exception {
+    //TODO
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,11 @@
             <artifactId>commons-collections4</artifactId>
             <version>${apache-commons-collections.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>1.3</version>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,14 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco-maven-plugin.version}</version>
+                <!--<configuration>-->
+                    <!--<excludes>-->
+                        <!--<exclude>gui/**</exclude>-->
+                        <!--<exclude>event/**</exclude>-->
+                        <!--&lt;!&ndash;<exclude>**/*.class</exclude>&ndash;&gt;-->
+                        <!--&lt;!&ndash;<exclude>**/*Dev.*</exclude>&ndash;&gt;-->
+                    <!--</excludes>-->
+                <!--</configuration>-->
                 <executions>
                     <!--
                         Prepares the property pointing to the JaCoCo runtime agent which
@@ -84,12 +92,12 @@
                                     <limit>
                                         <counter>INSTRUCTION</counter>
                                         <value>COVEREDRATIO</value>
-                                        <minimum>0.51</minimum>
+                                        <minimum>0.40</minimum>
                                     </limit>
                                     <limit>
                                         <counter>METHOD</counter>
                                         <value>COVEREDRATIO</value>
-                                        <minimum>0.57</minimum>
+                                        <minimum>0.40</minimum>
                                     </limit>
                                 </limits>
                             </rule>
@@ -97,6 +105,15 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <version>${assembly-plugin.version}</version>
+            <configuration>
+                <descriptorRefs>
+                    <descriptorRef>jar-with-dependencies</descriptorRef>
+                </descriptorRefs>
+            </configuration>
             </plugin>
         </plugins>
     </build>
@@ -125,6 +142,8 @@
         <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
         <java.version>1.8</java.version>
         <jacoco-maven-plugin.version>0.7.7.201606060606</jacoco-maven-plugin.version>
+        <apache-commons-collections.version>4.1</apache-commons-collections.version>
+        <assembly-plugin.version>2.6</assembly-plugin.version>
     </properties>
 
     <groupId>io.github.expansion-team</groupId>
@@ -163,6 +182,11 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <version>${surefire-plugin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>${apache-commons-collections.version}</version>
         </dependency>
     </dependencies>
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
@@ -33,14 +33,6 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco-maven-plugin.version}</version>
-                <!--<configuration>-->
-                    <!--<excludes>-->
-                        <!--<exclude>gui/**</exclude>-->
-                        <!--<exclude>event/**</exclude>-->
-                        <!--&lt;!&ndash;<exclude>**/*.class</exclude>&ndash;&gt;-->
-                        <!--&lt;!&ndash;<exclude>**/*Dev.*</exclude>&ndash;&gt;-->
-                    <!--</excludes>-->
-                <!--</configuration>-->
                 <executions>
                     <!--
                         Prepares the property pointing to the JaCoCo runtime agent which
@@ -81,39 +73,39 @@
                     <execution>
                         <id>default-check</id>
                         <goals>
-                        <goal>check</goal>
+                            <goal>check</goal>
                         </goals>
                         <configuration>
                             <dataFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</dataFile>
                             <rules>
-                            <rule>
-                                <element>BUNDLE</element>
-                                <limits>
-                                    <limit>
-                                        <counter>INSTRUCTION</counter>
-                                        <value>COVEREDRATIO</value>
-                                        <minimum>0.40</minimum>
-                                    </limit>
-                                    <limit>
-                                        <counter>METHOD</counter>
-                                        <value>COVEREDRATIO</value>
-                                        <minimum>0.40</minimum>
-                                    </limit>
-                                </limits>
-                            </rule>
-                        </rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.40</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>METHOD</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.40</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
             <plugin>
-            <artifactId>maven-assembly-plugin</artifactId>
-            <version>${assembly-plugin.version}</version>
-            <configuration>
-                <descriptorRefs>
-                    <descriptorRef>jar-with-dependencies</descriptorRef>
-                </descriptorRefs>
-            </configuration>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>${assembly-plugin.version}</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -10,6 +10,23 @@
     </parent>
 
     <artifactId>server</artifactId>
-    <version>0.9</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>io.github.expansionteam.battleships.Server</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>
 

--- a/server/src/main/resources/log4j.properties
+++ b/server/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 # Root logger option
-log4j.rootLogger=DEBUG, stdout, file
+log4j.rootLogger=TRACE, stdout, file
 
 # Redirect log messages to console
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender


### PR DESCRIPTION
Added possibility to create JAR and run from CLI

How to run:
mvn clean compile assembly:single install
java -jar ${module}-0.9-jar-with-dependencies.jar
- where ${module} is either client or server
  Added server ip address as application parameter.

When jar with dependecies is generated:
java -jar client-0.9-jar-with-dependencies.jar server_ip  
ex.  
java -jar client-0.9-jar-with-dependencies.jar 127.0.0.1
Changed log4j properties to enable TRACE level and rearranged lines in parent pom.

Added ip adress validator and some tests.

Added simple tests for ConnectionConfig.
Added ip adress validator from Guava.
Tests with console input were done manually:

Scenarios:
If the server is running and player gives
correct server ip adress, then he joins
to the room on server.

If player gives incorrect ip adress, then
application finishes execution (error log
message is generated, we need to handle it
better in the future).

If player gives no input, localhost
ip address is used.
Refactored MainLauncher class.

Extracted window size to constants.
